### PR TITLE
Switch blueMarble layer to URL template provider

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,9 +70,8 @@
       subdomains: ['a', 'b', 'c', 'd'],
       credit: new Cesium.Credit('© OpenStreetMap & CartoDB')
     }),
-    blueMarble: () => new Cesium.TileMapServiceImageryProvider({
-      url: 'https://s3.amazonaws.com/eox-a.s3-eu-central-1.amazonaws.com/blue-marble',
-      fileExtension: 'jpg',
+    blueMarble: () => new Cesium.UrlTemplateImageryProvider({
+      url: 'https://s3.amazonaws.com/eox-a.s3-eu-central-1.amazonaws.com/blue-marble/{z}/{x}/{y}.jpg',
       maximumLevel: 8,
       credit: new Cesium.Credit('NASA Blue Marble')
     }),


### PR DESCRIPTION
## Summary
- use `UrlTemplateImageryProvider` for Blue Marble tiles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee7f86208321bd19c6f64b6ef54c