### PR TITLE
Add pulsing outline to city borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,12 +194,28 @@
         const alpha = 0.5 + 0.5 * Math.sin(seconds * 4);
         return Cesium.Color.RED.withAlpha(alpha);
       }, false);
+
       viewer.entities.add({
         polygon: {
           hierarchy: Cesium.Cartesian3.fromDegreesArray(poly),
-          material: Cesium.Color.RED.withAlpha(0.3),
-          outline: true,
-          outlineColor: pulseColor
+          material: Cesium.Color.RED.withAlpha(0.3)
+        }
+      });
+
+      const positions = [];
+      for (let i = 0; i < poly.length; i += 2) {
+        positions.push(Cesium.Cartesian3.fromDegrees(poly[i], poly[i + 1]));
+      }
+      positions.push(positions[0]);
+
+      viewer.entities.add({
+        polyline: {
+          positions: positions,
+          width: 5,
+          material: new Cesium.PolylineGlowMaterialProperty({
+            glowPower: 0.2,
+            color: pulseColor
+          })
         }
       });
     });


### PR DESCRIPTION
## Summary
- highlight targeted city borders with pulsing glow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f0943b2f08321832a9413a6b0cc6c