### PR TITLE
Adjust pulsing border color and size

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
       const pulseColor = new Cesium.CallbackProperty(function(time) {
         const seconds = Cesium.JulianDate.secondsDifference(time, startTime);
         const alpha = 0.5 + 0.5 * Math.sin(seconds * 4);
-        return Cesium.Color.RED.withAlpha(alpha);
+        return Cesium.Color.fromCssColorString('#8b0000').withAlpha(alpha);
       }, false);
 
       viewer.entities.add({
@@ -211,7 +211,7 @@
       viewer.entities.add({
         polyline: {
           positions: positions,
-          width: 5,
+          width: 10,
           material: new Cesium.PolylineGlowMaterialProperty({
             glowPower: 0.2,
             color: pulseColor


### PR DESCRIPTION
## Summary
- make the pulsing polygon border thicker
- change the pulsing border to dark red

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f0c15f9a08321a1964e848759b682