### PR TITLE
Fix dark red outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,6 @@
       const pulseColor = new Cesium.CallbackProperty(function(time) {
         const seconds = Cesium.JulianDate.secondsDifference(time, startTime);
         const alpha = 0.5 + 0.5 * Math.sin(seconds * 4);
-        return Cesium.Color.RED.withAlpha(alpha);
         return Cesium.Color.fromCssColorString('#8b0000').withAlpha(alpha);
       }, false);
 
@@ -212,12 +211,8 @@
       viewer.entities.add({
         polyline: {
           positions: positions,
-          width: 5,
           width: 10,
-          material: new Cesium.PolylineGlowMaterialProperty({
-            glowPower: 0.2,
-            color: pulseColor
-          })
+          material: new Cesium.ColorMaterialProperty(pulseColor)
         }
       });
     });


### PR DESCRIPTION
## Summary
- fix color callback so pulsing outline uses `#8b0000`
- replace polyline glow with solid color material to remove white halo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fc200221083218ce7a941d91f498f